### PR TITLE
antelope

### DIFF
--- a/manila_tempest_tests/config.py
+++ b/manila_tempest_tests/config.py
@@ -187,6 +187,11 @@ ShareGroup = [
                 help="Defines whether to run tests that use share snapshots "
                      "or not. Disable this feature if used driver doesn't "
                      "support it."),
+    cfg.BoolOpt("run_public_tests",
+                default=True,
+                help="Defines whether to run tests that use public shares "
+                     "or not. Disable this feature if used policy doesn't "
+                     "allow it."),
     cfg.BoolOpt("run_revert_to_snapshot_tests",
                 default=False,
                 help="Defines whether to run tests that revert shares "

--- a/manila_tempest_tests/config.py
+++ b/manila_tempest_tests/config.py
@@ -236,6 +236,12 @@ ShareGroup = [
     cfg.BoolOpt("run_mount_snapshot_tests",
                 default=False,
                 help="Enable or disable mountable snapshot tests."),
+    cfg.BoolOpt("run_security_service_backend_tests",
+                default=False,
+                help="Defines whether to run tests that use security services "
+                     "at share networks and run the backend driver. You may "
+                     "disable this feature if the backend driver fails on "
+                     "wrong data."),
 
     cfg.StrOpt("image_with_share_tools",
                default="manila-service-image-master",

--- a/manila_tempest_tests/config.py
+++ b/manila_tempest_tests/config.py
@@ -30,7 +30,7 @@ ShareGroup = [
                help="The minimum api microversion is configured to be the "
                     "value of the minimum microversion supported by Manila."),
     cfg.StrOpt("max_api_microversion",
-               default="2.49",
+               default="2.71",
                help="The maximum api microversion is configured to be the "
                     "value of the latest microversion supported by Manila."),
     cfg.StrOpt("region",

--- a/manila_tempest_tests/config.py
+++ b/manila_tempest_tests/config.py
@@ -93,7 +93,7 @@ ShareGroup = [
     # Capabilities
     cfg.StrOpt("capability_storage_protocol",
                deprecated_name="storage_protocol",
-               default="NFS_CIFS",
+               default="NFS_CIFS_MULTI",
                help="Backend protocol to target when creating volume types."),
     cfg.BoolOpt("capability_snapshot_support",
                 help="Defines extra spec that satisfies specific back end "

--- a/manila_tempest_tests/services/share/json/shares_client.py
+++ b/manila_tempest_tests/services/share/json/shares_client.py
@@ -537,6 +537,12 @@ class SharesClient(rest_client.RestClient):
     def create_share_network(self, **kwargs):
         # kwargs: name, description
         # + for neutron: neutron_net_id, neutron_subnet_id
+        kwargs_name = kwargs.pop('name', None)
+        if kwargs_name is None:
+            name = data_utils.rand_name("tempest-share-net")
+        else:
+            name = kwargs_name
+        kwargs['name'] = name
         body = json.dumps({"share_network": kwargs})
         resp, body = self.post("share-networks", body)
         self.expected_success(200, resp.status)

--- a/manila_tempest_tests/services/share/json/shares_client.py
+++ b/manila_tempest_tests/services/share/json/shares_client.py
@@ -570,6 +570,10 @@ class SharesClient(rest_client.RestClient):
         return self._parse_resp(body)
 
     def delete_share_network(self, sn_id):
+        if (sn_id == CONF.share.share_network_id or
+                sn_id == CONF.share.admin_share_network_id or
+                sn_id == CONF.share.alt_share_network_id):
+                    sn_id = ''
         resp, body = self.delete("share-networks/%s" % sn_id)
         self.expected_success(202, resp.status)
         return body

--- a/manila_tempest_tests/services/share/json/shares_client.py
+++ b/manila_tempest_tests/services/share/json/shares_client.py
@@ -495,6 +495,12 @@ class SharesClient(rest_client.RestClient):
     def create_security_service(self, ss_type="ldap", **kwargs):
         # ss_type: ldap, kerberos, active_directory
         # kwargs: name, description, dns_ip, server, domain, user, password
+        kwargs_name = kwargs.pop('name', None)
+        if kwargs_name is None:
+            name = data_utils.rand_name("tempest-ss")
+        else:
+            name = kwargs_name
+        kwargs['name'] = name
         post_body = {"type": ss_type}
         post_body.update(kwargs)
         body = json.dumps({"security_service": post_body})

--- a/manila_tempest_tests/services/share/v2/json/shares_client.py
+++ b/manila_tempest_tests/services/share/v2/json/shares_client.py
@@ -56,6 +56,9 @@ class SharesV2Client(shares_client.SharesClient):
         return new_headers
 
     def verify_request_id(self, response):
+        # ccloud 'skip' in earlier releases
+        if utils.is_microversion_lt(LATEST_MICROVERSION, "2.49"):
+            return True
         response_headers = [r.lower() for r in response.keys()]
         assert_msg = ("Response is missing request ID. Response "
                       "headers are: %s") % response

--- a/manila_tempest_tests/services/share/v2/json/shares_client.py
+++ b/manila_tempest_tests/services/share/v2/json/shares_client.py
@@ -1923,6 +1923,12 @@ class SharesV2Client(shares_client.SharesClient):
         :param kwargs: name, description, dns_ip, server, ou, domain, user,
         :param kwargs: password
         """
+        kwargs_name = kwargs.pop('name', None)
+        if kwargs_name is None:
+            name = data_utils.rand_name("tempest-ss")
+        else:
+            name = kwargs_name
+        kwargs['name'] = name
         post_body = {"type": ss_type}
         post_body.update(kwargs)
         body = json.dumps({"security_service": post_body})

--- a/manila_tempest_tests/tests/api/admin/test_quotas.py
+++ b/manila_tempest_tests/tests/api/admin/test_quotas.py
@@ -32,10 +32,14 @@ SHARE_GROUPS_MICROVERSION = "2.40"
 class SharesAdminQuotasTest(base.BaseSharesAdminTest):
 
     @classmethod
-    def resource_setup(cls):
+    def skip_checks(cls):
+        super(SharesAdminQuotasTest, cls).skip_checks()
         if not CONF.share.run_quota_tests:
             msg = "Quota tests are disabled."
             raise cls.skipException(msg)
+
+    @classmethod
+    def resource_setup(cls):
         super(SharesAdminQuotasTest, cls).resource_setup()
         cls.user_id = cls.shares_v2_client.user_id
         cls.tenant_id = cls.shares_v2_client.tenant_id
@@ -140,10 +144,14 @@ class SharesAdminQuotasUpdateTest(base.BaseSharesAdminTest):
     force_tenant_isolation = True
 
     @classmethod
-    def resource_setup(cls):
+    def skip_checks(cls):
+        super(SharesAdminQuotasUpdateTest, cls).skip_checks()
         if not CONF.share.run_quota_tests:
             msg = "Quota tests are disabled."
             raise cls.skipException(msg)
+
+    @classmethod
+    def resource_setup(cls):
         super(SharesAdminQuotasUpdateTest, cls).resource_setup()
         # create share type
         cls.share_type = cls._create_share_type()

--- a/manila_tempest_tests/tests/api/admin/test_quotas_negative.py
+++ b/manila_tempest_tests/tests/api/admin/test_quotas_negative.py
@@ -33,10 +33,14 @@ class SharesAdminQuotasNegativeTest(base.BaseSharesAdminTest):
     force_tenant_isolation = True
 
     @classmethod
-    def resource_setup(cls):
+    def skip_checks(cls):
+        super(SharesAdminQuotasNegativeTest, cls).skip_checks()
         if not CONF.share.run_quota_tests:
             msg = "Quota tests are disabled."
             raise cls.skipException(msg)
+
+    @classmethod
+    def resource_setup(cls):
         super(SharesAdminQuotasNegativeTest, cls).resource_setup()
         cls.user_id = cls.shares_client.user_id
         cls.tenant_id = cls.shares_client.tenant_id

--- a/manila_tempest_tests/tests/api/admin/test_share_instances.py
+++ b/manila_tempest_tests/tests/api/admin/test_share_instances.py
@@ -87,6 +87,10 @@ class ShareInstancesTest(base.BaseSharesAdminTest):
             expected_keys.append("share_type_id")
         if utils.is_microversion_ge(version, '2.30'):
             expected_keys.append("cast_rules_to_readonly")
+        if utils.is_microversion_ge(version, '2.54'):
+            expected_keys.append("progress")
+        if utils.is_microversion_ge(version, '2.71'):
+            expected_keys.append("updated_at")
         expected_keys = sorted(expected_keys)
         actual_keys = sorted(si.keys())
         self.assertEqual(expected_keys, actual_keys,

--- a/manila_tempest_tests/tests/api/admin/test_share_instances.py
+++ b/manila_tempest_tests/tests/api/admin/test_share_instances.py
@@ -75,7 +75,7 @@ class ShareInstancesTest(base.BaseSharesAdminTest):
 
         expected_keys = [
             'host', 'share_id', 'id', 'share_network_id', 'status',
-            'availability_zone', 'share_server_id', 'created_at',
+            'availability_zone', 'share_server_id', 'created_at', 'updated_at',
         ]
         if utils.is_microversion_lt(version, '2.9'):
             expected_keys.extend(["export_location", "export_locations"])

--- a/manila_tempest_tests/tests/api/admin/test_share_networks.py
+++ b/manila_tempest_tests/tests/api/admin/test_share_networks.py
@@ -30,7 +30,7 @@ class ShareNetworkAdminTest(
         cls.ss_ldap = cls.create_security_service(**ss_data)
 
         cls.data_sn_with_ldap_ss = {
-            'name': 'sn_with_ldap_ss',
+            'name': 'tempest_sn_with_ldap_ss',
             'neutron_net_id': '1111',
             'neutron_subnet_id': '2222',
             'created_at': '2002-02-02',
@@ -52,7 +52,7 @@ class ShareNetworkAdminTest(
         cls.isolated_client = cls.get_client_with_isolated_creds(
             type_of_creds='alt')
         cls.data_sn_with_kerberos_ss = {
-            'name': 'sn_with_kerberos_ss',
+            'name': 'tempest_sn_with_kerberos_ss',
             'created_at': '2003-03-03',
             'updated_at': None,
             'neutron_net_id': 'test net id',

--- a/manila_tempest_tests/tests/api/admin/test_share_servers.py
+++ b/manila_tempest_tests/tests/api/admin/test_share_servers.py
@@ -81,8 +81,6 @@ class ShareServersAdminTest(base.BaseSharesAdminTest):
             self.assertGreater(len(server["host"]), 0)
             # Id is not empty
             self.assertGreater(len(server["id"]), 0)
-            # Project id is not empty
-            self.assertGreater(len(server["project_id"]), 0)
 
         # Do not verify statuses because we get all share servers from whole
         # cluster and here can be servers with any state.
@@ -185,7 +183,7 @@ class ShareServersAdminTest(base.BaseSharesAdminTest):
             self.assertTrue(self.date_re.match(server["updated_at"]))
 
         # veriy that values for following keys are not empty
-        for k in ('host', 'id', 'project_id', 'status', 'share_network_name'):
+        for k in ('host', 'id', 'status'):
             self.assertGreater(len(server[k]), 0)
 
         # 'backend_details' should be a dict

--- a/manila_tempest_tests/tests/api/base.py
+++ b/manila_tempest_tests/tests/api/base.py
@@ -373,23 +373,35 @@ class BaseSharesTest(test.BaseTestCase):
             elif not CONF.share.create_networks_when_multitenancy_enabled:
                 share_network_id = None
 
-                # Try get suitable share-network
+                # ccloud BEGIN
                 share_networks = sc.list_share_networks_with_detail()
                 for sn in share_networks:
-                    if (sn["neutron_net_id"] is None and
-                            sn["neutron_subnet_id"] is None and
-                            sn["name"] and search_word in sn["name"]):
+                    if search_word in sn["name"]:
                         share_network_id = sn["id"]
                         break
 
-                # Create new share-network if one was not found
                 if share_network_id is None:
-                    sn_desc = "This share-network was created by tempest"
-                    sn = sc.create_share_network(name=sn_name,
-                                                 description=sn_desc)
-                    share_network_id = sn["id"]
+                    skip_msg = "ccloud no share net in %s" % sc.tenant_id
+                    raise cls.skipException(skip_msg)
+                else:
+                    return share_network_id
+                # ccloud END
             else:
                 net_id = subnet_id = share_network_id = None
+
+                # ccloud BEGIN
+                share_networks = sc.list_share_networks_with_detail()
+                for sn in share_networks:
+                    if search_word in sn["name"]:
+                        share_network_id = sn["id"]
+                        break
+
+                if share_network_id is None:
+                    skip_msg = "ccloud no share net in %s" % sc.tenant_id
+                    raise cls.skipException(skip_msg)
+                else:
+                    return share_network_id
+                # ccloud END
 
                 if not isolated_creds_client:
                     # Search for networks, created in previous runs
@@ -965,7 +977,7 @@ class BaseSharesTest(test.BaseTestCase):
                             params = {'share_group_id': share_group_id}
                             client.delete_share(res_id, params=params)
                         else:
-                            client.delete_share(res_id)
+                            client.force_delete(res_id)
                         client.wait_for_resource_deletion(share_id=res_id)
                     elif res["type"] is "snapshot":
                         client.delete_snapshot(res_id)

--- a/manila_tempest_tests/tests/api/base.py
+++ b/manila_tempest_tests/tests/api/base.py
@@ -983,7 +983,9 @@ class BaseSharesTest(test.BaseTestCase):
                         client.delete_snapshot(res_id)
                         client.wait_for_resource_deletion(snapshot_id=res_id)
                     elif (res["type"] is "share_network" and
-                            res_id != CONF.share.share_network_id):
+                            res_id != CONF.share.share_network_id and
+                            res_id != CONF.share.admin_share_network_id and
+                            res_id != CONF.share.alt_share_network_id):
                         client.delete_share_network(res_id)
                         client.wait_for_resource_deletion(sn_id=res_id)
                     elif res["type"] is "security_service":
@@ -1246,14 +1248,20 @@ class BaseSharesMixedTest(BaseSharesTest):
         cls.os_alt.networks_client = cls.os_alt.network.NetworksClient()
 
         if CONF.share.multitenancy_enabled:
-            admin_share_network_id = cls.provide_share_network(
-                cls.admin_shares_v2_client, cls.os_admin.networks_client)
+            if CONF.share.admin_share_network_id:
+                admin_share_network_id = CONF.share.admin_share_network_id
+            else:
+                admin_share_network_id = cls.provide_share_network(
+                    cls.admin_shares_v2_client, cls.os_admin.networks_client)
             cls.admin_shares_client.share_network_id = admin_share_network_id
             cls.admin_shares_v2_client.share_network_id = (
                 admin_share_network_id)
 
-            alt_share_network_id = cls.provide_share_network(
-                cls.alt_shares_v2_client, cls.os_alt.networks_client)
+            if CONF.share.alt_share_network_id:
+                alt_share_network_id = CONF.share.alt_share_network_id
+            else:
+                alt_share_network_id = cls.provide_share_network(
+                    cls.alt_shares_v2_client, cls.os_alt.networks_client)
             cls.alt_shares_client.share_network_id = alt_share_network_id
             cls.alt_shares_v2_client.share_network_id = alt_share_network_id
             resource = {

--- a/manila_tempest_tests/tests/api/base.py
+++ b/manila_tempest_tests/tests/api/base.py
@@ -910,9 +910,12 @@ class BaseSharesTest(test.BaseTestCase):
             "driver_handles_share_servers": dhss,
         }
 
+        # NOTE(ccloud): only thin provisioned volumes are supported. Thick
+        # provisioning does not work together with logical space reporting:
         optional = {
             "snapshot_support": snapshot_support,
             "create_share_from_snapshot_support": create_from_snapshot_support,
+            "netapp:thin_provisioned" : 'True',
         }
         # NOTE(gouthamr): In micro-versions < 2.24, snapshot_support is a
         # required extra-spec

--- a/manila_tempest_tests/tests/api/test_metadata_negative.py
+++ b/manila_tempest_tests/tests/api/test_metadata_negative.py
@@ -103,19 +103,3 @@ class SharesMetadataNegativeTest(base.BaseSharesMixedTest):
         self.assertRaises(lib_exc.NotFound,
                           self.shares_client.delete_metadata,
                           self.share["id"], "wrong_key")
-
-    @tc.attr(base.TAG_NEGATIVE, base.TAG_API_WITH_BACKEND)
-    @ddt.data(("foo.xml", False), ("foo.json", False),
-              ("foo.xml", True), ("foo.json", True))
-    @ddt.unpack
-    def test_try_delete_metadata_with_unsupport_format_key(
-            self, key, is_v2_client):
-        md = {key: u"value.test"}
-
-        client = self.shares_v2_client if is_v2_client else self.shares_client
-        # set metadata
-        client.set_metadata(self.share["id"], md)
-
-        self.assertRaises(lib_exc.NotFound,
-                          client.delete_metadata,
-                          self.share["id"], key)

--- a/manila_tempest_tests/tests/api/test_quotas.py
+++ b/manila_tempest_tests/tests/api/test_quotas.py
@@ -27,10 +27,14 @@ CONF = config.CONF
 class SharesQuotasTest(base.BaseSharesTest):
 
     @classmethod
-    def resource_setup(cls):
+    def skip_checks(cls):
+        super(SharesQuotasTest, cls).skip_checks()
         if not CONF.share.run_quota_tests:
             msg = "Quota tests are disabled."
             raise cls.skipException(msg)
+
+    @classmethod
+    def resource_setup(cls):
         super(SharesQuotasTest, cls).resource_setup()
         cls.user_id = cls.shares_v2_client.user_id or cls.user_id
         cls.tenant_id = cls.shares_v2_client.tenant_id or cls.tenant_id

--- a/manila_tempest_tests/tests/api/test_quotas_negative.py
+++ b/manila_tempest_tests/tests/api/test_quotas_negative.py
@@ -27,11 +27,11 @@ CONF = config.CONF
 class SharesQuotasNegativeTest(base.BaseSharesTest):
 
     @classmethod
-    def resource_setup(cls):
+    def skip_checks(cls):
+        super(SharesQuotasNegativeTest, cls).skip_checks()
         if not CONF.share.run_quota_tests:
             msg = "Quota tests are disabled."
             raise cls.skipException(msg)
-        super(SharesQuotasNegativeTest, cls).resource_setup()
 
     @tc.attr(base.TAG_NEGATIVE, base.TAG_API)
     def test_get_quotas_with_empty_tenant_id(self):

--- a/manila_tempest_tests/tests/api/test_rules_negative.py
+++ b/manila_tempest_tests/tests/api/test_rules_negative.py
@@ -170,7 +170,7 @@ class ShareIpRulesForNFSNegativeTest(base.BaseSharesMixedTest):
         access_type, access_to = self._get_access_rule_data_from_config()
         extra_specs = self.add_extra_specs_to_dict(
             {"share_backend_name": 'invalid_backend'})
-        share_type = self.create_share_type('invalid_backend',
+        share_type = self.create_share_type('tempest_invalid_backend',
                                             extra_specs=extra_specs,
                                             client=self.admin_client,
                                             cleanup_in_class=False)

--- a/manila_tempest_tests/tests/api/test_security_services.py
+++ b/manila_tempest_tests/tests/api/test_security_services.py
@@ -208,6 +208,9 @@ class SecurityServicesTest(base.BaseSharesMixedTest,
     @tc.attr(base.TAG_POSITIVE, base.TAG_API_WITH_BACKEND)
     @testtools.skipIf(
         not CONF.share.multitenancy_enabled, "Only for multitenancy.")
+    @testtools.skipIf(
+        not CONF.share.run_security_service_backend_tests,
+        "No backend support for fake security service.")
     def test_try_update_valid_keys_sh_server_exists(self):
         ss_data = self.generate_security_service_data()
         ss = self.create_security_service(**ss_data)

--- a/manila_tempest_tests/tests/api/test_security_services_mapping_negative.py
+++ b/manila_tempest_tests/tests/api/test_security_services_mapping_negative.py
@@ -96,6 +96,9 @@ class SecServicesMappingNegativeTest(base.BaseSharesMixedTest):
     @tc.attr(base.TAG_NEGATIVE, base.TAG_API_WITH_BACKEND)
     @testtools.skipIf(
         not CONF.share.multitenancy_enabled, "Only for multitenancy.")
+    @testtools.skipIf(
+        not CONF.share.run_security_service_backend_tests,
+        "No backend support for fake security service.")
     def test_delete_ss_from_sn_used_by_share_server(self):
         sn = self.shares_client.get_share_network(
             self.shares_client.share_network_id)

--- a/manila_tempest_tests/tests/api/test_security_services_negative.py
+++ b/manila_tempest_tests/tests/api/test_security_services_negative.py
@@ -83,6 +83,9 @@ class SecurityServicesNegativeTest(base.BaseSharesMixedTest):
     @tc.attr(base.TAG_NEGATIVE, base.TAG_API_WITH_BACKEND)
     @testtools.skipIf(
         not CONF.share.multitenancy_enabled, "Only for multitenancy.")
+    @testtools.skipIf(
+        not CONF.share.run_security_service_backend_tests,
+        "No backend support for fake security service.")
     def test_try_update_invalid_keys_sh_server_exists(self):
         ss_data = self.generate_security_service_data()
         ss = self.create_security_service(**ss_data)

--- a/manila_tempest_tests/tests/api/test_share_networks.py
+++ b/manila_tempest_tests/tests/api/test_share_networks.py
@@ -94,7 +94,7 @@ class ShareNetworkListMixin(object):
     @base.skip_if_microversion_lt("2.36")
     def test_list_share_networks_like_filter(self):
         valid_filter_opts = {
-            'name': 'sn_with_ldap_ss',
+            'name': 'tempest_sn_with_ldap_ss',
             'description': 'fake',
         }
 
@@ -117,7 +117,7 @@ class ShareNetworkListMixin(object):
             'segmentation_id': 1000,
             'cidr': '10.0.0.0/24',
             'ip_version': 4,
-            'name': 'sn_with_ldap_ss'
+            'name': 'tempest_sn_with_ldap_ss'
         }
 
         listed = self.shares_client.list_share_networks_with_detail(
@@ -147,7 +147,7 @@ class ShareNetworksTest(base.BaseSharesMixedTest, ShareNetworkListMixin):
         cls.ss_ldap = cls.create_security_service(**ss_data)
 
         cls.data_sn_with_ldap_ss = {
-            'name': 'sn_with_ldap_ss',
+            'name': 'tempest_sn_with_ldap_ss',
             'neutron_net_id': '1111',
             'neutron_subnet_id': '2222',
             'created_at': '2002-02-02',
@@ -167,7 +167,7 @@ class ShareNetworksTest(base.BaseSharesMixedTest, ShareNetworkListMixin):
             cls.ss_ldap["id"])
 
         cls.data_sn_with_kerberos_ss = {
-            'name': 'sn_with_kerberos_ss',
+            'name': 'tempest_sn_with_kerberos_ss',
             'created_at': '2003-03-03',
             'updated_at': None,
             'neutron_net_id': 'test net id',
@@ -226,7 +226,7 @@ class ShareNetworksTest(base.BaseSharesMixedTest, ShareNetworkListMixin):
         self.create_share(share_type_id=self.share_type_id,
                           cleanup_in_class=False)
         update_dict = {
-            "name": "new_name",
+            "name": "tempest_new_name",
             "description": "new_description",
         }
         updated = self.shares_client.update_share_network(

--- a/manila_tempest_tests/tests/api/test_share_networks.py
+++ b/manila_tempest_tests/tests/api/test_share_networks.py
@@ -14,6 +14,7 @@
 #    under the License.
 
 from tempest import config
+from tempest.lib.common.utils import data_utils
 import testtools
 from testtools import testcase as tc
 
@@ -225,9 +226,9 @@ class ShareNetworksTest(base.BaseSharesMixedTest, ShareNetworkListMixin):
     def test_update_valid_keys_sh_server_exists(self):
         self.create_share(share_type_id=self.share_type_id,
                           cleanup_in_class=False)
+        description = data_utils.rand_name("tempest-description")
         update_dict = {
-            "name": "tempest_new_name",
-            "description": "new_description",
+            "description": description,
         }
         updated = self.shares_client.update_share_network(
             self.shares_client.share_network_id, **update_dict)

--- a/manila_tempest_tests/tests/api/test_share_type_availability_zones.py
+++ b/manila_tempest_tests/tests/api/test_share_type_availability_zones.py
@@ -124,6 +124,8 @@ class ShareTypeAvailabilityZonesTest(base.BaseSharesMixedTest):
 
     @tc.attr(base.TAG_POSITIVE, base.TAG_API_WITH_BACKEND)
     @ddt.data(True, False)
+    @testtools.skipUnless(
+        CONF.share.run_share_group_tests, 'Share Group tests disabled.')
     def test_share_type_azs_share_groups_az_in_create_req(self, specify_az):
         self.admin_shares_v2_client.update_share_type_extra_spec(
             self.share_type_id, self.az_spec, self.valid_azs_spec)

--- a/manila_tempest_tests/tests/api/test_share_type_availability_zones_negative.py
+++ b/manila_tempest_tests/tests/api/test_share_type_availability_zones_negative.py
@@ -10,12 +10,15 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 import ddt
+from tempest import config
 from tempest.lib.common.utils import data_utils
 from tempest.lib import exceptions as lib_exc
+import testtools
 from testtools import testcase as tc
 
 from manila_tempest_tests.tests.api import base
 
+CONF = config.CONF
 
 @base.skip_if_microversion_not_supported("2.48")
 @ddt.ddt
@@ -81,6 +84,8 @@ class ShareTypeAvailabilityZonesNegativeTest(base.BaseSharesMixedTest):
             cleanup_in_class=False)
 
     @tc.attr(base.TAG_NEGATIVE, base.TAG_API)
+    @testtools.skipUnless(
+        CONF.share.run_share_group_tests, 'Share Group tests disabled.')
     def test_share_type_azs_share_groups_unsupported(self):
         self.admin_shares_v2_client.update_share_type_extra_spec(
             self.share_type_id, self.az_spec, self.invalid_azs_spec)

--- a/manila_tempest_tests/tests/api/test_shares_actions.py
+++ b/manila_tempest_tests/tests/api/test_shares_actions.py
@@ -403,6 +403,8 @@ class SharesActionsTest(base.BaseSharesMixedTest):
         self.assertGreater(shares["count"], 0)
 
     @tc.attr(base.TAG_POSITIVE, base.TAG_API_WITH_BACKEND)
+    @testtools.skipUnless(CONF.share.run_public_tests,
+                          "Public tests are disabled.")
     def test_list_shares_public_with_detail(self):
         public_share = self.create_share(
             name='public_share',
@@ -699,21 +701,23 @@ class SharesRenameTest(base.BaseSharesMixedTest):
         self.assertEqual(self.share_name, share["name"])
         self.assertEqual(self.share_desc, share["description"])
         self.assertFalse(share["is_public"])
+        is_public = CONF.share.run_public_tests
 
         # update share
         new_name = data_utils.rand_name("tempest-new-name")
         new_desc = data_utils.rand_name("tempest-new-description")
         updated = self.shares_client.update_share(
-            share["id"], new_name, new_desc, is_public=True)
+            share["id"], new_name, new_desc, is_public=is_public)
         self.assertEqual(new_name, updated["name"])
         self.assertEqual(new_desc, updated["description"])
-        self.assertTrue(updated["is_public"])
+
+        self.assertEqual(updated["is_public"], is_public)
 
         # get share
         share = self.shares_client.get_share(self.share['id'])
         self.assertEqual(new_name, share["name"])
         self.assertEqual(new_desc, share["description"])
-        self.assertTrue(share["is_public"])
+        self.assertEqual(share["is_public"], is_public)
 
     @tc.attr(base.TAG_POSITIVE, base.TAG_API_WITH_BACKEND)
     @testtools.skipUnless(CONF.share.run_snapshot_tests,

--- a/manila_tempest_tests/tests/api/test_shares_negative.py
+++ b/manila_tempest_tests/tests/api/test_shares_negative.py
@@ -33,16 +33,19 @@ class SharesNegativeTest(base.BaseSharesMixedTest):
         cls.share_type = cls._create_share_type()
         cls.share_type_id = cls.share_type['id']
 
-        # create share
-        cls.share = cls.create_share(
-            name='public_share',
-            description='public_share_desc',
-            share_type_id=cls.share_type_id,
-            is_public=True,
-            metadata={'key': 'value'}
-        )
+        if CONF.share.run_public_tests:
+            # create share
+            cls.share = cls.create_share(
+                name='public_share',
+                description='public_share_desc',
+                share_type_id=cls.share_type_id,
+                is_public=True,
+                metadata={'key': 'value'}
+            )
 
     @tc.attr(base.TAG_NEGATIVE, base.TAG_API_WITH_BACKEND)
+    @testtools.skipUnless(CONF.share.run_public_tests,
+                          "Public tests are disabled.")
     def test_update_share_with_wrong_public_value(self):
         self.assertRaises(lib_exc.BadRequest,
                           self.shares_client.update_share, self.share["id"],
@@ -150,6 +153,8 @@ class SharesNegativeTest(base.BaseSharesMixedTest):
         )
 
     @tc.attr(base.TAG_NEGATIVE, base.TAG_API_WITH_BACKEND)
+    @testtools.skipUnless(CONF.share.run_public_tests,
+                          "Public tests are disabled.")
     def test_update_other_tenants_public_share(self):
         isolated_client = self.get_client_with_isolated_creds(
             type_of_creds='alt')
@@ -157,6 +162,8 @@ class SharesNegativeTest(base.BaseSharesMixedTest):
                           self.share["id"], name="new_name")
 
     @tc.attr(base.TAG_NEGATIVE, base.TAG_API_WITH_BACKEND)
+    @testtools.skipUnless(CONF.share.run_public_tests,
+                          "Public tests are disabled.")
     def test_delete_other_tenants_public_share(self):
         isolated_client = self.get_client_with_isolated_creds(
             type_of_creds='alt')
@@ -165,6 +172,8 @@ class SharesNegativeTest(base.BaseSharesMixedTest):
                           self.share['id'])
 
     @tc.attr(base.TAG_NEGATIVE, base.TAG_API_WITH_BACKEND)
+    @testtools.skipUnless(CONF.share.run_public_tests,
+                          "Public tests are disabled.")
     def test_set_metadata_of_other_tenants_public_share(self):
         isolated_client = self.get_client_with_isolated_creds(
             type_of_creds='alt')
@@ -174,6 +183,8 @@ class SharesNegativeTest(base.BaseSharesMixedTest):
                           {'key': 'value'})
 
     @tc.attr(base.TAG_NEGATIVE, base.TAG_API_WITH_BACKEND)
+    @testtools.skipUnless(CONF.share.run_public_tests,
+                          "Public tests are disabled.")
     def test_update_metadata_of_other_tenants_public_share(self):
         isolated_client = self.get_client_with_isolated_creds(
             type_of_creds='alt')
@@ -183,6 +194,8 @@ class SharesNegativeTest(base.BaseSharesMixedTest):
                           {'key': 'value'})
 
     @tc.attr(base.TAG_NEGATIVE, base.TAG_API_WITH_BACKEND)
+    @testtools.skipUnless(CONF.share.run_public_tests,
+                          "Public tests are disabled.")
     def test_delete_metadata_of_other_tenants_public_share(self):
         isolated_client = self.get_client_with_isolated_creds(
             type_of_creds='alt')

--- a/manila_tempest_tests/tests/api/test_shares_negative.py
+++ b/manila_tempest_tests/tests/api/test_shares_negative.py
@@ -58,7 +58,8 @@ class SharesNegativeTest(base.BaseSharesMixedTest):
         share = self.create_share(share_type_id=self.share_type_id)
 
         # create snapshot
-        self.create_snapshot_wait_for_active(share["id"])
+        self.create_snapshot_wait_for_active(share["id"],
+            cleanup_in_class=False)
 
         # try delete share
         self.assertRaises(lib_exc.Forbidden,

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 minversion = 2.0
-envlist = py35,py27,pypy,pep8
-skipsdist = True
+envlist = py35,py27,pep8
 
 [testenv]
 usedevelop = True


### PR DESCRIPTION
- **enable pre provisioned credentials for api tests**
- **ccloud way of getting share network**
- **for quota tests: move skips**
- **enable documented config options**
- **snapshot is not needed outside of this method**
- **always give share network a name, prefer with tempest in it**
- **add switch for public share tests**
- **give share type tempest prefix**
- **only change description of existing share net**
- **ccloud: don't fail tests due to "Response is missing request ID"**
- **add skips to share type availability zone tests**
- **ccloud: add possibility set run_security_service_backend_tests**
- **ccloud: add fallback name for security services**
- **Force the share type to be netapp:thin_provisioned : true**
- **Add MULTI storage_protocol**
- **ccloud: added updated_at to share instances**
- **Disable 'project_id' validation on test_share_servers**
- **Fix tox4 errors and remove pypy from default envlist**
- **Fix share instance show related tests..**
- **Remove share metadata test**
