### PR TITLE
Fix snapshot tests to expect provider_location field

### DIFF
--- a/manila_tempest_tests/tests/api/test_shares_actions.py
+++ b/manila_tempest_tests/tests/api/test_shares_actions.py
@@ -457,6 +457,8 @@ class SharesActionsTest(base.BaseSharesMixedTest):
         expected_keys = ["status", "links", "share_id", "name",
                          "share_proto", "created_at",
                          "description", "id", "share_size", "size"]
+        if version and utils.is_microversion_ge(version, '2.12'):
+            expected_keys.append("provider_location")
         if version and utils.is_microversion_ge(version, '2.17'):
             expected_keys.extend(["user_id", "project_id"])
         actual_keys = snapshot.keys()
@@ -532,6 +534,8 @@ class SharesActionsTest(base.BaseSharesMixedTest):
         expected_keys = ["status", "links", "share_id", "name",
                          "share_proto", "created_at", "description", "id",
                          "share_size", "size"]
+        if version and utils.is_microversion_ge(version, '2.12'):
+            expected_keys.append("provider_location")
         if version and utils.is_microversion_ge(version, '2.17'):
             expected_keys.extend(["user_id", "project_id"])
 


### PR DESCRIPTION
Fix snapshot tests to expect provider_location field

After https://github.com/sapcc/manila/commit/5a6304e77ff06d084937b58337521cbc667ebc8f,
the provider_location field is now visible to all users (not just
admins) starting from microversion 2.12.

This fix updates the test expectations in test_get_snapshot and
test_list_snapshots_with_detail to include provider_location in
the expected keys for microversion 2.12 and later.

Fixes the following failing tests:
- test_get_snapshot_2_2_16
- test_list_snapshots_with_detail_2_2_16
- test_list_snapshots_with_detail_3_2_36

Similarly, this is only a quick-fix for the tests to pass.

Change-Id: If95d8dc6115d6a6e33bfacbe0e62857abd85f38f